### PR TITLE
fix: use ansible_facts[] to silence INJECT_FACTS_AS_VARS deprecation

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -4,8 +4,8 @@ venv_path: "/opt/k3s-venv"
 python_bin: "{{ ansible_facts.python.executable | default('/usr/bin/python3') }}"
 python_version: 3
 python_pip_name: python3-pip
-epel_rpm_key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
-required_repo: "{% if ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7' %}epel-release{% elif ansible_distribution == 'CentOS' and ansible_distribution_major_version is version('8', '>=') %}https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm{% elif ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('7', '>=') %}https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm{% endif %}"
+epel_rpm_key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_facts['distribution_major_version'] }}"
+required_repo: "{% if ansible_facts['distribution'] == 'CentOS' and ansible_facts['distribution_major_version'] == '7' %}epel-release{% elif ansible_facts['distribution'] == 'CentOS' and ansible_facts['distribution_major_version'] is version('8', '>=') %}https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm{% elif ansible_facts['distribution'] == 'RedHat' and ansible_facts['distribution_major_version'] is version('7', '>=') %}https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm{% endif %}"
 update_packages: false
 collection_install_parameter: --force
 ansible_collections: {}

--- a/tasks/os-packages.yaml
+++ b/tasks/os-packages.yaml
@@ -12,7 +12,7 @@
   tags: update
   ansible.builtin.apt:
     upgrade: dist
-  when: update_packages|bool and ansible_os_family == 'Debian'
+  when: update_packages|bool and ansible_facts['os_family'] == 'Debian'
 
 - name: Install os packages
   ansible.builtin.package:

--- a/tasks/os-requirements.yaml
+++ b/tasks/os-requirements.yaml
@@ -3,21 +3,21 @@
   ansible.builtin.rpm_key:
     state: present
     key: "{{ epel_rpm_key }}"
-  when: update_packages|bool and ansible_distribution == 'CentOS'
+  when: update_packages|bool and ansible_facts['distribution'] == 'CentOS'
 
 - name: Add epel for RHEL9
   ansible.builtin.shell: |
     subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
     dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
   changed_when: true
-  when: ansible_distribution == 'RedHat'
+  when: ansible_facts['distribution'] == 'RedHat'
 
 - name: Update apt-cache
   ansible.builtin.apt:
     update_cache: true
-  when: update_packages|bool and ansible_os_family == 'Debian'
+  when: update_packages|bool and ansible_facts['os_family'] == 'Debian'
 
-- name: "Install required repo for {{ ansible_distribution }} {{ ansible_distribution_version }}"
+- name: "Install required repo for {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_version'] }}"
   ansible.builtin.package:
     name: "{{ required_repo }}"
     state: present

--- a/tasks/python-modules.yaml
+++ b/tasks/python-modules.yaml
@@ -14,7 +14,7 @@
       - "python{{ python_version }}-venv"
       - "python{{ python_version }}-dev"
     state: present
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts['os_family'] == 'Debian'
 
 - name: Ensure Python venv and dev packages are installed (RedHat/Fedora)
   package:
@@ -22,7 +22,7 @@
       - python3-devel
       - python3-pip
     state: present
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts['os_family'] == 'RedHat'
 
 - name: Create virtual environment
   command: "{{ python_bin }} -m venv {{ venv_path }}"
@@ -37,7 +37,7 @@
   become: true
 
 - name: Upgrade pip and setuptools to avoid Python 3.12+ issues
-  command: "{{ venv_path }}/bin/pip install --upgrade pip setuptools"
+  command: "{{ venv_path }}/bin/pip install --upgrade pip setuptools packaging"
   become: true
   changed_when: false
 


### PR DESCRIPTION
## Summary
- Replace top-level `ansible_distribution*` / `ansible_os_family` refs with `ansible_facts[...]` form in `defaults/main.yaml` (`epel_rpm_key`, `required_repo`) and tasks (`os-packages`, `os-requirements`, `python-modules`).
- Silences `INJECT_FACTS_AS_VARS` deprecation warnings on ansible-core 2.20+ and prepares for removal in 2.24.

Refs: stuttgart-things/ansible#829

## Test plan
- [ ] Run `sthings.baseos.setup` against Ubuntu 24.04 + a RedHat target; confirm no deprecation warnings and correct branching behavior.