### PR TITLE
ci: switch ansible-lint image to ghcr.io/stuttgart-things/sthings-ans…

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,6 @@ jobs:
       runs-on: ghr-install-requirements-in-cluster
       environment-name: k8s
       continue-error: true
-      ansible-image: eu.gcr.io/stuttgart-things/sthings-ansible:9.3.0-1
+      ansible-image: ghcr.io/stuttgart-things/sthings-ansible:13.5.0-test
       playbook: tests/test.yml
     needs: yaml-lint


### PR DESCRIPTION
…ible:13.5.0-test

The previous image eu.gcr.io/stuttgart-things/sthings-ansible:9.3.0-1 is no longer pullable (GCR has been sunset), which caused the Ansible-Lint job's container pod to hang in Pending and fail with "custom container implementation failed" on every PR — including all Renovate PRs — making it look like the pipelines weren't running.

https://claude.ai/code/session_016KDDL7iToD7jZoPRxBLWRi