### PR TITLE
fix: skip "Install required repo" when there is no repo to install

### DIFF
--- a/tasks/os-requirements.yaml
+++ b/tasks/os-requirements.yaml
@@ -17,9 +17,16 @@
     update_cache: true
   when: update_packages|bool and ansible_facts['os_family'] == 'Debian'
 
+# `required_repo` (defaults/main.yaml) is an if/elif chain covering only CentOS
+# and RedHat, with no {% else %} — on every Debian/Ubuntu host it renders to the
+# empty string. Without the guard this task calls `package: name: ""` and fails
+# with `No package matching '' is available` on each run, which ignore_errors
+# then swallows. Skip it instead: an expected red `fatal:` on every host trains
+# people to skim past the ones that matter.
 - name: "Install required repo for {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_version'] }}"
   ansible.builtin.package:
     name: "{{ required_repo }}"
     state: present
   tags: install
+  when: required_repo | default('') | length > 0
   ignore_errors: true


### PR DESCRIPTION
Closes #43.

## The defect

`required_repo` (`defaults/main.yaml`) is an if/elif chain covering only CentOS and RedHat, with **no `{% else %}`**. On every Debian/Ubuntu host it renders to the empty string, so the task called `package: name: ""`:

```
TASK [Install required repo for Ubuntu 26.04]
fatal: [default]: FAILED! => {"changed": false, "msg": "No package matching '' is available"}
```

`ignore_errors: true` swallowed it, which is exactly why it survived: nothing broke, it just printed a red `fatal:` on every Debian-family run. That is its own cost — an expected `fatal:` on every host trains people to skim past the ones that matter. It appeared **five times** in a single LabUL ubuntu26 Packer build (`ok=62 changed=19 failed=0 ignored=5`).

## The change

```yaml
  when: required_repo | default('') | length > 0
```

Skip the task where there is genuinely nothing to install, instead of attempting it and hiding the result.

`ignore_errors` is left in place **deliberately**: it now only covers the RedHat/CentOS path, where an EPEL install can fail for real reasons. Whether that should remain ignored is a separate call and not part of this fix.

## Tested

`tasks/os-requirements.yaml` parses; the task carries `when: required_repo | default('') | length > 0`. Behaviour by platform:

- Debian/Ubuntu → `required_repo` is `""` → **skipped** (was: fatal, ignored)
- CentOS/RedHat → a package name or EPEL URL → **runs unchanged**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSaY8SQK6q9nFWj4rAvZWc