### PR TITLE
fix: guard required_repo against None, not just undefined

### DIFF
--- a/tasks/os-requirements.yaml
+++ b/tasks/os-requirements.yaml
@@ -18,15 +18,23 @@
   when: update_packages|bool and ansible_facts['os_family'] == 'Debian'
 
 # `required_repo` (defaults/main.yaml) is an if/elif chain covering only CentOS
-# and RedHat, with no {% else %} — on every Debian/Ubuntu host it renders to the
-# empty string. Without the guard this task calls `package: name: ""` and fails
-# with `No package matching '' is available` on each run, which ignore_errors
-# then swallows. Skip it instead: an expected red `fatal:` on every host trains
+# and RedHat, with no {% else %}, so on every Debian/Ubuntu host no branch is
+# taken. Unguarded, this task calls `package: name: ""` and fails with
+# `No package matching '' is available` on each run, which ignore_errors then
+# swallows. Skip it instead: an expected red `fatal:` on every host trains
 # people to skim past the ones that matter.
+#
+# `default('', true)` — the second argument is load-bearing. Under jinja2_native
+# (ansible-core's default) a template whose branches are all false evaluates to
+# None, NOT to ''. Plain `default('')` substitutes only for UNDEFINED, so None
+# passes straight through to `length` and the guard fails with
+# `The filter plugin 'ansible.builtin.length' failed: object of type 'NoneType'
+# has no len()` — trading one red fatal for another. The boolean form also
+# substitutes for falsy values, which covers both None and ''.
 - name: "Install required repo for {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_version'] }}"
   ansible.builtin.package:
     name: "{{ required_repo }}"
     state: present
   tags: install
-  when: required_repo | default('') | length > 0
+  when: required_repo | default('', true) | length > 0
   ignore_errors: true


### PR DESCRIPTION
Follow-up to #50. That guard traded one red `fatal:` for another.

## Symptom

Every Debian/Ubuntu run since the guard landed reports:

```
fatal: [default]: FAILED! => {"changed": false, "msg": "Task failed: A 'when' expression failed:
The filter plugin 'ansible.builtin.length' failed: object of type 'NoneType' has no len()"}
...ignoring
```

instead of the `No package matching '' is available` it was meant to remove. `ignore_errors` swallows both, so the task still "passes" and the noise the change set out to eliminate is still there.

## Why

The premise in the comment was wrong. It claimed the if/elif chain "renders to the empty string" on non-RedHat hosts. Under **jinja2_native**, which is ansible-core's default, a template whose branches are all false renders to `None`:

```
plain jinja2                       -> ''    (type str)
jinja2_native (ansible default)    -> None  (type NoneType)
```

`default('')` substitutes only for **undefined**, so `None` passes straight through to `length`.

## Fix

`default('', true)` — the boolean second argument also substitutes for falsy values, covering `None` and `''` alike.

## Verified

Against ansible-core 2.17.14. `ANSIBLE_JINJA2_NATIVE=1` reproduces the build failure exactly; without it the old guard skips cleanly, which is why review missed this:

| | old guard | new guard |
|---|---|---|
| no branch taken, `jinja2_native` | `fatal: … NoneType has no len()`, ignored | `skipping` |
| no branch taken, plain jinja2 | `skipping` | `skipping` |
| `required_repo` actually set | installs | installs |

Caught in a real vSphere template build (`ubuntu24-base-20260730-0715`), not in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSaY8SQK6q9nFWj4rAvZWc